### PR TITLE
feat: add initial blog structure with sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,18 @@
+import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home.jsx";
+import Actu from "./pages/Actu.jsx";
+import Nostalgie from "./pages/Nostalgie.jsx";
+import Critique from "./pages/Critique.jsx";
 
 function App() {
-  return <Home />;
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/actu" element={<Actu />} />
+      <Route path="/nostalgie" element={<Nostalgie />} />
+      <Route path="/critique" element={<Critique />} />
+    </Routes>
+  );
 }
 
 export default App;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,16 @@
+import { Link } from "react-router-dom";
+
+export default function Layout({ children }) {
+  return (
+    <div className="min-h-screen bg-neutral-100 text-neutral-900 flex flex-col">
+      <header className="p-6 border-b border-neutral-300 bg-white shadow-sm">
+        <Link to="/" className="text-3xl font-serif font-bold">Regard DLP</Link>
+        <p className="text-sm text-neutral-500">Actu — Nostalgie — Critique</p>
+      </header>
+      <main className="flex-1 p-6">{children}</main>
+      <footer className="p-6 text-center text-xs text-neutral-500 border-t border-neutral-300">
+        Blog personnel non affilié à The Walt Disney Company © 2025
+      </footer>
+    </div>
+  );
+}

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export function Button({
+  children,
+  variant = "default",
+  className = "",
+  asChild = false,
+  ...props
+}) {
+  const base =
+    "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none";
+  const variants = {
+    default: "bg-neutral-900 text-white hover:bg-neutral-700",
+    link: "text-neutral-700 underline-offset-4 hover:underline bg-transparent",
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      className: `${base} ${variants[variant] || ""} ${className} ${children.props.className || ""}`,
+      ...props,
+    });
+  }
+
+  return (
+    <button
+      className={`${base} ${variants[variant] || ""} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/pages/Actu.jsx
+++ b/src/pages/Actu.jsx
@@ -1,0 +1,20 @@
+import Layout from "../components/Layout";
+
+export default function Actu() {
+  const posts = [
+    "Pourquoi le merchandising d’été déçoit",
+  ];
+
+  return (
+    <Layout>
+      <h2 className="text-2xl font-semibold mb-4">📰 Actualités</h2>
+      <ul className="space-y-4">
+        {posts.map((title, idx) => (
+          <li key={idx} className="border-b pb-2">
+            {title}
+          </li>
+        ))}
+      </ul>
+    </Layout>
+  );
+}

--- a/src/pages/Critique.jsx
+++ b/src/pages/Critique.jsx
@@ -1,0 +1,20 @@
+import Layout from "../components/Layout";
+
+export default function Critique() {
+  const posts = [
+    "Le land Marvel trahit-il la promesse Disney ?",
+  ];
+
+  return (
+    <Layout>
+      <h2 className="text-2xl font-semibold mb-4">🔍 Critiques</h2>
+      <ul className="space-y-4">
+        {posts.map((title, idx) => (
+          <li key={idx} className="border-b pb-2">
+            {title}
+          </li>
+        ))}
+      </ul>
+    </Layout>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,16 +1,12 @@
 import { Card, CardContent } from "../components/ui/card";
 import { Button } from "../components/ui/button";
 import { Link } from "react-router-dom";
+import Layout from "../components/Layout";
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-neutral-100 text-neutral-900">
-      <header className="p-6 border-b border-neutral-300 bg-white shadow-sm">
-        <h1 className="text-3xl font-serif font-bold">Regard DLP</h1>
-        <p className="text-sm text-neutral-500">Actu — Nostalgie — Critique</p>
-      </header>
-
-      <main className="p-6 grid grid-cols-1 md:grid-cols-3 gap-6">
+    <Layout>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Bloc Actu */}
         <Card>
           <CardContent className="p-6">
@@ -49,11 +45,7 @@ export default function Home() {
             </Button>
           </CardContent>
         </Card>
-      </main>
-
-      <footer className="p-6 text-center text-xs text-neutral-500 border-t border-neutral-300">
-        Blog personnel non affilié à The Walt Disney Company © 2025
-      </footer>
-    </div>
+      </div>
+    </Layout>
   );
 }

--- a/src/pages/Nostalgie.jsx
+++ b/src/pages/Nostalgie.jsx
@@ -1,0 +1,20 @@
+import Layout from "../components/Layout";
+
+export default function Nostalgie() {
+  const posts = [
+    "Discoveryland et la SF rétro de mon enfance",
+  ];
+
+  return (
+    <Layout>
+      <h2 className="text-2xl font-semibold mb-4">🕰 Nostalgie</h2>
+      <ul className="space-y-4">
+        {posts.map((title, idx) => (
+          <li key={idx} className="border-b pb-2">
+            {title}
+          </li>
+        ))}
+      </ul>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable site layout and button components
- implement Actu, Nostalgie, and Critique pages with sample posts
- configure routing and home page links for the blog

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e85f7505083279b075459ed9af97f